### PR TITLE
Fix robots.txt sitemap placeholder

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,2 @@
 User-agent: *
 Allow: /
-Sitemap: [URL_DE_VOTRE_SITEMAP_ICI_QUAND_IL_SERA_CREE]/sitemap.xml


### PR DESCRIPTION
## Summary
- remove unused sitemap line from `robots.txt`

## Testing
- `npm test --silent` *(fails: This environment doesn't have network access after setup, so Codex couldn't run certain commands)*

------
https://chatgpt.com/codex/tasks/task_b_683a750fdab883249f3ea993612dc46f