### PR TITLE
Add OpenAI dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@genkit-ai/next": "^1.0.4",
+        "@genkit-ai/openai": "^1.0.0",
         "@hookform/resolvers": "^4.1.3",
         "@radix-ui/react-accordion": "^1.2.3",
         "@radix-ui/react-alert-dialog": "^1.1.6",
@@ -1255,6 +1256,9 @@
         "next": "^15.0.0",
         "zod": "^3.24.1"
       }
+    },
+    "node_modules/@genkit-ai/openai": {
+      "version": "1.0.0"
     },
     "node_modules/@genkit-ai/telemetry-server": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@genkit-ai/next": "^1.0.4",
+    "@genkit-ai/openai": "^1.0.0",
     "@hookform/resolvers": "^4.1.3",
     "@radix-ui/react-accordion": "^1.2.3",
     "@radix-ui/react-alert-dialog": "^1.1.6",


### PR DESCRIPTION
## Summary
- add `@genkit-ai/openai` to package.json and package-lock.json

## Testing
- `npm install` *(fails: connect EHOSTUNREACH)*

------
https://chatgpt.com/codex/tasks/task_b_683a7c52f8e883249baf9af537b62e0a