### PR TITLE
Fix DeepSeek message schema

### DIFF
--- a/src/ai/ai-instance.ts
+++ b/src/ai/ai-instance.ts
@@ -1,11 +1,11 @@
 
 import { genkit } from 'genkit';
-import deepseek, { deepseekChat, deepseekReasoner } from 'genkitx-deepseek';
+import wrappedDeepseek, { deepseekChat, deepseekReasoner } from './plugins/wrapped-deepseek';
 
 export const ai = genkit({
   promptDir: './prompts',
   plugins: [
-    deepseek({
+    wrappedDeepseek({
       apiKey: process.env.DEEPSEEK_API_KEY,
     }),
   ],

--- a/src/ai/plugins/wrapped-deepseek.ts
+++ b/src/ai/plugins/wrapped-deepseek.ts
@@ -1,0 +1,54 @@
+import { genkitPlugin } from 'genkit/plugin';
+import deepseek, { deepseekChat, deepseekReasoner } from 'genkitx-deepseek';
+import { SUPPORTED_DEEPSEEK_MODELS } from 'genkitx-deepseek/dist/models';
+import { deepseekRunner } from 'genkitx-deepseek/dist/runner';
+import { OpenAI } from 'openai';
+
+export interface PluginOptions {
+  apiKey?: string;
+  baseURL?: string;
+}
+
+export { deepseekChat, deepseekReasoner };
+
+export const wrappedDeepseek = (options?: PluginOptions) =>
+  genkitPlugin('wrapped-deepseek', async (ai) => {
+    // Initialize original deepseek plugin to ensure any side effects
+    await deepseek(options)(ai);
+
+    const apiKey = options?.apiKey || process.env.DEEPSEEK_API_KEY;
+    if (!apiKey) {
+      throw new Error('Deepseek API key is required. Pass plugin options or set DEEPSEEK_API_KEY environment variable.');
+    }
+
+    const baseURL = options?.baseURL || process.env.DEEPSEEK_API_URL || 'https://api.deepseek.com';
+    const client = new OpenAI({ apiKey, baseURL });
+
+    const wrapRunner = (runner: any) => async (request: any, streamingCallback?: any) => {
+      const result = await runner(request, streamingCallback);
+      if (result?.candidates) {
+        result.candidates = result.candidates.map((c: any) => ({
+          ...c,
+          message: {
+            role: c.message.role,
+            content: [{ text: c.message.text }],
+          },
+        }));
+      }
+      return result;
+    };
+
+    for (const name of Object.keys(SUPPORTED_DEEPSEEK_MODELS)) {
+      const model = SUPPORTED_DEEPSEEK_MODELS[name];
+      ai.defineModel(
+        {
+          name: model.name,
+          ...model.info,
+          configSchema: model.configSchema,
+        },
+        wrapRunner(deepseekRunner(name, client))
+      );
+    }
+  });
+
+export default wrappedDeepseek;


### PR DESCRIPTION
## Summary
- wrap the `deepseek` plugin so messages return `content` instead of `text`
- use the wrapped plugin in the Genkit instance

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683d0252d1b48324a4e667dba975505b